### PR TITLE
Tell Zeitwerk to ignore `install` folder

### DIFF
--- a/lib/phlex.rb
+++ b/lib/phlex.rb
@@ -6,6 +6,7 @@ require "syntax_tree"
 
 loader = Zeitwerk::Loader.for_gem(warn_on_extra_files: false)
 loader.ignore("#{__dir__}/generators")
+loader.ignore("#{__dir__}/install")
 loader.inflector.inflect("html" => "HTML")
 loader.inflector.inflect("vcall" => "VCall")
 loader.inflector.inflect("fcall" => "FCall")


### PR DESCRIPTION
Eager loading a Rails app in production was failing due to the install file getting loaded in accidentally (it should only be run in the context of a Rake task). This patch fixes the bug.